### PR TITLE
Fix empty cssRules

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@ const CLASS_IDENT_REGEX =
   /\.-?(?:[_a-z]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])(?:[_a-z0-9-]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])*/gi;
 
 export function isGroupingRule(rule: any): rule is CSSGroupingRule {
-  return rule && 'cssRules' in rule;
+  return rule && 'cssRules' in rule && rule.cssRules.length > 0;
 }
 
 export function isCSSStyleRule(rule: any): rule is CSSStyleRule {


### PR DESCRIPTION
In our case, `#processStylesheet` doesn't detect any classes.

Going deeper, it comes from the method `isGroupingRule` because the object "rule" has "cssRules" but is empty. 
So, rule never pass through `isCSSStyleRule` method just after.